### PR TITLE
Adds filter for active jobs

### DIFF
--- a/JobData.cs
+++ b/JobData.cs
@@ -98,7 +98,8 @@ namespace DvMod.RemoteDispatch
                     new JProperty("requiredLicenses", RequiredLicenses(job)),
                     new JProperty("length", TotalLength(mainTask)),
                     new JProperty("mass", TotalMass(mainTask) / 1000),
-                    new JProperty("basePayment", job.GetBasePaymentForTheJob()));
+                    new JProperty("basePayment", job.GetBasePaymentForTheJob()),
+                    new JProperty("isActive", job.State == JobState.InProgress));
             }
 
             // ensure cache is updated
@@ -126,6 +127,19 @@ namespace DvMod.RemoteDispatch
                             jobIdForCar.Remove(car);
                         else
                             jobIdForCar[car] = jobId;
+                        Sessions.AddTag("jobs");
+                    }
+                }
+            }
+            [HarmonyPatch(typeof(Job))]
+            public static class UpdateJobStatePatches
+            {
+                [HarmonyPostfix]
+                [HarmonyPatch(nameof(Job.TakeJob))]
+                public static void TakeJobPostfix(Job __instance, bool takenViaLoadGame)
+                {
+                    if (!takenViaLoadGame)
+                    {
                         Sessions.AddTag("jobs");
                     }
                 }

--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
     </div>
     <div class="leaflet-sidebar-pane" id="jobsTab">
       <input id="jobSearchText" type="text" placeholder="Search...">
+      <label>active only<input id="jobActiveOnly" type="checkbox"></label>
       <table id="jobList">
         <tbody id="jobListBody"></tbody>
       </table>

--- a/main.js
+++ b/main.js
@@ -165,10 +165,11 @@ function yardIdForTrack(trackId) {
 }
 
 function jobMatchesFilter(jobId, jobData) {
-  const testText = document.getElementById('jobSearchText').value.toUpperCase();
+    const testText = document.getElementById('jobSearchText').value.toUpperCase();
+    const activeOnly = document.getElementById('jobActiveOnly').checked;
   function taskFields(task) { return [task.startTrack, task.destinationTrack].concat(task.cars); }
   const fields = [jobId].concat(jobData.tasks.flatMap(taskFields));
-  return fields.some(field => field.includes(testText));
+  return fields.some(field => field.includes(testText)) && (!activeOnly || jobData.isActive);
 }
 
 function jobElem(jobId, jobData) {
@@ -288,11 +289,17 @@ function updateAllJobs(jobs) {
 }
 
 let jobSearchTimeoutId = null;
+function queueJobUpdate() {
+    if (jobSearchTimeoutId)
+        clearTimeout(jobSearchTimeoutId);
+    jobSearchTimeoutId = setTimeout(updateJobList, 100);
+}
 document.getElementById('jobSearchText').addEventListener('input', e => {
-  if (jobSearchTimeoutId)
-    clearTimeout(jobSearchTimeoutId);
-  jobSearchTimeoutId = setTimeout(updateJobList, 100);
+    queueJobUpdate();
 });
+document.getElementById('jobActiveOnly').addEventListener('change', e => {
+    queueJobUpdate();
+})
 
 /////////////////////
 // track

--- a/style.css
+++ b/style.css
@@ -186,3 +186,14 @@ body {
 .locoControlButton:active {
   background-color: lightblue;
 }
+#jobsTab input {
+    float:left;
+    clear:left;
+}
+#jobsTab label {
+    float:left;
+    clear: left;
+}
+#jobList {
+    clear: left;
+}


### PR DESCRIPTION
Updates jobs when job is accepted.  Useful for managing jobs as you pass through areas that generate new jobs or if using persistent jobs mod

I wrote this after using my update that supports persistent jobs and realizing I'd like an easy way to see the jobs in my train which usually matches with the jobs that I've accepted.  It's not always doable to just use certain search parameters as sometimes you have mixed FH and LH jobs and also sometimes you are in an area with multiple jobs heading back where you came from.  Active jobs lets you just show those jobs you've accepted.