### PR TITLE
add Horn, Sander Controls; Wheelslip indicator; fix loco selection resetting when a new loco spawns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 /obj/
 /dv
 /.idea/
+/res/
 Directory.Build.targets
+dv-remote-dispatch.sln

--- a/CarData.cs
+++ b/CarData.cs
@@ -109,6 +109,7 @@ namespace DvMod.RemoteDispatch
     {
         public readonly bool canCouple;
         public readonly bool isSlipping;
+        public readonly bool isSandOn;
         public readonly int carsInFront;
         public readonly int carsInRear;
         public readonly float brakePipe;
@@ -131,6 +132,7 @@ namespace DvMod.RemoteDispatch
             ILocomotiveRemoteControl controller = trainCar.GetComponent<ILocomotiveRemoteControl>();
             canCouple = controller.IsCouplerInRange(ExternalCouplingHandler.COUPLING_RANGE);
             isSlipping = controller.IsWheelslipping();
+            isSandOn = controller.IsSandOn();
             carsInFront = controller.GetNumberOfCarsInFront();
             carsInRear = controller.GetNumberOfCarsInRear();
             forwardSpeed = trainCar.GetForwardSpeed();
@@ -147,6 +149,7 @@ namespace DvMod.RemoteDispatch
             carObj.Add("canBeControlled", true);
             carObj.Add("canCouple", canCouple);
             carObj.Add("isSlipping", isSlipping);
+            carObj.Add("isSandOn", isSandOn);
             carObj.Add("carsInFront", carsInFront);
             carObj.Add("carsInRear", carsInRear);
             carObj.Add("forwardSpeed", forwardSpeed * 60 * 60 / 1000);

--- a/LocoControl.cs
+++ b/LocoControl.cs
@@ -49,6 +49,9 @@ namespace DvMod.RemoteDispatch
                 case "uncouple":
                     controller.Uncouple((int)value);
                     break;
+                case "horn":
+                    controller.controlsOverrider.Horn?.Set(value01);
+                    break;
                 default:
                     return false;
                 }

--- a/LocoControl.cs
+++ b/LocoControl.cs
@@ -52,6 +52,9 @@ namespace DvMod.RemoteDispatch
                 case "horn":
                     controller.controlsOverrider.Horn?.Set(value01);
                     break;
+                case "sander":
+                    controller.controlsOverrider.Sander?.Set(value01);
+                    break;
                 default:
                     return false;
                 }

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
           <label for="locoControlSander">Sander</label>
         </div>
         <div>
-          <input type="radio" id="locoWheelslipDisplay" name="horn" disabled>
+          <input type="radio" id="locoWheelslipDisplay" name="wheelslip" disabled>
           <laber for="locoWheelslipDisplay">Wheelslip</laber>
         </div>
         <div>

--- a/index.html
+++ b/index.html
@@ -71,6 +71,9 @@
           <button id="locoControlUncoupleButton">Uncouple</button>
           <select id="locoControlUncoupleSelect"></select>
         </div>
+        <div>
+          <button id="locoControlHorn">Horn</button>
+        </div>
       </div>
     </div>
     <div class="leaflet-sidebar-pane" id="settingsTab">

--- a/index.html
+++ b/index.html
@@ -65,15 +65,23 @@
           <input id="locoControlThrottleInput" type="range">
         </div>
         <div>
+          <input type="checkbox" id="locoControlSander" name="sander">
+          <label for="locoControlSander">Sander</label>
+        </div>
+        <div>
+          <input type="radio" id="locoWheelslipDisplay" name="horn" disabled>
+          <laber for="locoWheelslipDisplay">Wheelslip</laber>
+        </div>
+        <div>
+          <button id="locoControlHorn">Horn</button>
+        </div>
+        <br/>
+        <div>
           <button id="locoControlCoupleButton">Couple</button>
         </div>
         <div>
           <button id="locoControlUncoupleButton">Uncouple</button>
           <select id="locoControlUncoupleSelect"></select>
-        </div>
-        <div>
-          <button id="locoControlHorn">Horn</button>
-          <input type="radio" id="locoHornDisplay" name="horn" disabled>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
         </div>
         <div>
           <button id="locoControlHorn">Horn</button>
+          <input type="radio" id="locoHornDisplay" name="horn" disabled>
         </div>
       </div>
     </div>

--- a/main.js
+++ b/main.js
@@ -620,6 +620,8 @@ const locoControlCoupleButton = document.getElementById('locoControlCoupleButton
 const locoControlUncoupleButton = document.getElementById('locoControlUncoupleButton');
 const locoControlUncoupleSelect = document.getElementById('locoControlUncoupleSelect');
 
+const locoControlHorn = document.getElementById('locoControlHorn');
+
 function updateCouplingControls(carData) {
   const canCouple = carData.canCouple;
   const carsInFront = carData.carsInFront;
@@ -743,6 +745,9 @@ locoThrottleInput.addEventListener("mouseup", () => {
   locoThrottleEditing = false;
   updateLocoDisplay();
 });
+
+locoControlHorn.addEventListener('mousedown',e => sendLocoCommand('horn=1'));
+locoControlHorn.addEventListener('mouseup',e => sendLocoCommand('horn=0'));
 
 
 /////////////////////

--- a/main.js
+++ b/main.js
@@ -633,7 +633,8 @@ const locoControlUncoupleButton = document.getElementById('locoControlUncoupleBu
 const locoControlUncoupleSelect = document.getElementById('locoControlUncoupleSelect');
 
 const locoControlHorn = document.getElementById('locoControlHorn');
-const locoHornDisplay = document.getElementById('locoHornDisplay');
+const locoWheelslipDisplay = document.getElementById('locoWheelslipDisplay');
+const locoControlSander = document.getElementById('locoControlSander');
 
 function updateCouplingControls(carData) {
   const canCouple = carData.canCouple;
@@ -675,7 +676,7 @@ function getControlledLocoData() {
 let locoTrainBrakeEditing = false;
 let locoIndependentBrakeEditing = false;
 let locoThrottleEditing = false;
-let locoHornEditing = false;
+let locoSanderEditing = false;
 
 function updateLocoTrainBrakeInput(carData) {
   if (locoTrainBrakeEditing)
@@ -695,10 +696,12 @@ function updateLocoThrottleInput(carData) {
   locoThrottleInput.value = carData.throttle * 100;
 }
 
-function updateLocoHornDisplay(carData) {
-  if (locoHornEditing)
-    return;
-  locoHornDisplay.value = carData.horn;
+function updateWheelslipDisplay(carData){
+  locoWheelslipDisplay.checked=carData.isSlipping;
+}
+
+function updateSanderDisplay(carData){
+  locoControlSander.checked=carData.isSandOn;
 }
 
 function updateLocoDisplay() {
@@ -712,7 +715,8 @@ function updateLocoDisplay() {
         updateReverserButtons(carData.reverser);
         updateLocoThrottleInput(carData);
         updateCouplingControls(carData);
-        updateLocoHornDisplay(carData);});
+        updateWheelslipDisplay(carData);
+        updateSanderDisplay(carData);});
     }catch(e){
       console.warn("Couldn't load current loco data");
     }
@@ -772,7 +776,8 @@ locoThrottleInput.addEventListener("mouseup", () => {
 
 locoControlHorn.addEventListener('mousedown',e => sendLocoCommand('horn=1'));
 locoControlHorn.addEventListener('mouseup',e => sendLocoCommand('horn=0'));
-
+locoControlHorn.addEventListener('mouseout',e => sendLocoCommand('horn=0'));
+locoControlSander.addEventListener('click',e=> sendLocoCommand(`sander=${locoControlSander.checked ? 1 : 0}`))
 
 /////////////////////
 // cars

--- a/main.js
+++ b/main.js
@@ -580,6 +580,10 @@ fetch(new URL('/player', location))
 
 const locoIdSelect = document.getElementById('locoControlLocoId');
 function updateLocoList() {
+  var currLoco="000";
+  if(locoIdSelect.length>0){
+    currLoco=locoIdSelect.options[locoIdSelect.selectedIndex].text;//save current loco
+  }
   for (const elem of Array.from(locoIdSelect.children))
     elem.remove();
   const locoIds = Array.from(allCarData.entries())
@@ -590,6 +594,13 @@ function updateLocoList() {
     const option = document.createElement('option');
     option.textContent = id;
     locoIdSelect.appendChild(option);
+  }
+  //restore previous selection
+  var i;
+  for (i=0;i<locoIdSelect.length;i++){
+    if(locoIdSelect.options[i].text==currLoco){
+      locoIdSelect.options.selectedIndex=i;
+    }
   }
 }
 
@@ -690,20 +701,20 @@ function updateLocoHornDisplay(carData) {
 }
 
 function updateLocoDisplay() {
-  try{
-    getControlledLocoData()
-    .then(carData => {
-      locoBrakePipeDisplay.textContent = carData.brakePipe.toFixed(1);
-      locoSpeedDisplay.textContent = carData.forwardSpeed.toFixed(0);
-      updateLocoTrainBrakeInput(carData);
-      updateLocoIndependentBrakeInput(carData);
-      updateReverserButtons(carData.reverser);
-      updateLocoThrottleInput(carData);
-      updateCouplingControls(carData);
-      updateLocoHornDisplay(carData);
-  });} catch(e){
-    return;
-  }
+    try{
+      getControlledLocoData()
+      .then(carData => {
+        locoBrakePipeDisplay.textContent = carData.brakePipe.toFixed(1);
+        locoSpeedDisplay.textContent = carData.forwardSpeed.toFixed(0);
+        updateLocoTrainBrakeInput(carData);
+        updateLocoIndependentBrakeInput(carData);
+        updateReverserButtons(carData.reverser);
+        updateLocoThrottleInput(carData);
+        updateCouplingControls(carData);
+        updateLocoHornDisplay(carData);});
+    }catch(e){
+      console.warn("Couldn't load current loco data");
+    }
 }
 
 let locoControlRefreshIntervalId;

--- a/main.js
+++ b/main.js
@@ -621,6 +621,7 @@ const locoControlUncoupleButton = document.getElementById('locoControlUncoupleBu
 const locoControlUncoupleSelect = document.getElementById('locoControlUncoupleSelect');
 
 const locoControlHorn = document.getElementById('locoControlHorn');
+const locoHornDisplay = document.getElementById('locoHornDisplay');
 
 function updateCouplingControls(carData) {
   const canCouple = carData.canCouple;
@@ -662,6 +663,7 @@ function getControlledLocoData() {
 let locoTrainBrakeEditing = false;
 let locoIndependentBrakeEditing = false;
 let locoThrottleEditing = false;
+let locoHornEditing = false;
 
 function updateLocoTrainBrakeInput(carData) {
   if (locoTrainBrakeEditing)
@@ -681,17 +683,27 @@ function updateLocoThrottleInput(carData) {
   locoThrottleInput.value = carData.throttle * 100;
 }
 
+function updateLocoHornDisplay(carData) {
+  if (locoHornEditing)
+    return;
+  locoHornDisplay.value = carData.horn;
+}
+
 function updateLocoDisplay() {
-  getControlledLocoData()
-  .then(carData => {
-    locoBrakePipeDisplay.textContent = carData.brakePipe.toFixed(1);
-    locoSpeedDisplay.textContent = carData.forwardSpeed.toFixed(0);
-    updateLocoTrainBrakeInput(carData);
-    updateLocoIndependentBrakeInput(carData);
-    updateReverserButtons(carData.reverser);
-    updateLocoThrottleInput(carData);
-    updateCouplingControls(carData);
-  });
+  try{
+    getControlledLocoData()
+    .then(carData => {
+      locoBrakePipeDisplay.textContent = carData.brakePipe.toFixed(1);
+      locoSpeedDisplay.textContent = carData.forwardSpeed.toFixed(0);
+      updateLocoTrainBrakeInput(carData);
+      updateLocoIndependentBrakeInput(carData);
+      updateReverserButtons(carData.reverser);
+      updateLocoThrottleInput(carData);
+      updateCouplingControls(carData);
+      updateLocoHornDisplay(carData);
+  });} catch(e){
+    return;
+  }
 }
 
 let locoControlRefreshIntervalId;

--- a/main.js
+++ b/main.js
@@ -580,9 +580,10 @@ fetch(new URL('/player', location))
 
 const locoIdSelect = document.getElementById('locoControlLocoId');
 function updateLocoList() {
+  //save current loco
   var currLoco="000";
   if(locoIdSelect.length>0){
-    currLoco=locoIdSelect.options[locoIdSelect.selectedIndex].text;//save current loco
+    currLoco=locoIdSelect.options[locoIdSelect.selectedIndex].text;
   }
   for (const elem of Array.from(locoIdSelect.children))
     elem.remove();


### PR DESCRIPTION
Added Horn and Sander controls as well as a Wheeslip indicator to the Loco Control tab

![image](https://github.com/mspielberg/dv-remote-dispatch/assets/16525015/36d1513c-d864-42f4-abdc-6a6da780845e)

Fixed an issue where the loco selection would reset to the first on the list whenever a new loco would spawn.

Caught a TypeError exception that would spam the console if WebUI wasn't connected to the server