### PR TITLE
Update the Rails while dragging/zooming

### DIFF
--- a/main.js
+++ b/main.js
@@ -26,6 +26,12 @@ const zoomHome = new L.Control.ZoomHome({
 
 let markerToFollow;
 map.addEventListener('mousedown', stopFollowing);
+map.on('drag', () => {
+    map.fitBounds(map.getBounds());
+});
+map.on('zoomanim', () => {
+    map.fitBounds(map.getBounds());
+});
 
 function setMarkerToFollow(marker) {
   markerToFollow = marker;


### PR DESCRIPTION
This little patch makes it a lot smoother the pull around the map.
Updating it while moving, to keep the rails from disappearing.
Zooming still acts a bit weird, only updating after completion of a zoom.