### PR TITLE
Use css grid instead of tbodys in job list

### DIFF
--- a/main.js
+++ b/main.js
@@ -111,7 +111,6 @@ function updateCarRow(carId) {
 /////////////////////
 // jobs
 
-const CarsPerRow = 3;
 const allJobData = new Map();
 const carJobIds = new Map();
 const jobListBody = document.getElementById('jobListBody');
@@ -182,13 +181,12 @@ function jobMatchesFilter(jobId, jobData) {
 function jobElem(jobId, jobData) {
   function replaceHyphens(s) { return s.replaceAll('-', '\u2011'); }
 
-  const tbody = document.createElement('tbody');
-  tbody.setAttribute('id', `jobList-${jobId}`);
+  const jobContainer = document.createElement('div');
+  jobContainer.setAttribute('id', `jobList-${jobId}`);
+  jobContainer.classList.add('jobList-grid');
 
-  let row = document.createElement('tr');
-  const jobIdCell = document.createElement('th'); 
-  jobIdCell.setAttribute('colspan', CarsPerRow);
-  jobIdCell.classList.add("jobList-jobHeader");
+  const jobIdCell = document.createElement('div');
+  jobIdCell.classList.add('jobList-jobHeader');
   jobIdCell.style.background = colorForJobId(jobId);
   jobIdCell.textContent = jobId;
 
@@ -198,64 +196,51 @@ function jobElem(jobId, jobData) {
       jobLicensesDiv.innerHTML += `<span class="jobList-license"><div class="jobList-licenseBackground"></div><img src="res/licenses.${license}.png" title="${license}"></span>`;
   }
   jobIdCell.appendChild(jobLicensesDiv);
+  jobContainer.appendChild(jobIdCell);
 
-  row.appendChild(jobIdCell);
-  tbody.appendChild(row);
-
-  row = document.createElement('tr');
-  jobMassCell = document.createElement('th');
+  const jobMassCell = document.createElement('div');
+  jobMassCell.classList.add('jobList-grid-metadata', 'jobList-metadata-start');
   jobMassCell.textContent = `${jobData.mass.toFixed(0)} t`;
-  jobLengthCell = document.createElement('th');
+  const jobLengthCell = document.createElement('div');
+  jobLengthCell.classList.add('jobList-grid-metadata');
   jobLengthCell.textContent = `${jobData.length.toFixed(0)} m`;
-  jobPaymentCell = document.createElement('th');
+  const jobPaymentCell = document.createElement('div');
+  jobPaymentCell.classList.add('jobList-grid-metadata');
   jobPaymentCell.textContent =
     new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 })
     .format(jobData.basePayment);
-  row.append(jobMassCell, jobLengthCell, jobPaymentCell);
-  tbody.appendChild(row);
+  jobContainer.append(jobMassCell, jobLengthCell, jobPaymentCell);
 
   jobData.tasks.forEach(task => {
-    row = document.createElement('tr');
-    const startTrackCell = document.createElement('th');
-    startTrackCell.classList.add('interactive');
+    const startTrackCell = document.createElement('div');
+    startTrackCell.classList.add('interactive', 'jobList-grid-metadata', 'jobList-metadata-start');
     startTrackCell.textContent = replaceHyphens(task.startTrack);
     startTrackCell.style.background = colorForYardId(yardIdForTrack(task.startTrack));
     startTrackCell.addEventListener('click', () => scrollToTrack(task.startTrack));
-    row.appendChild(startTrackCell);
+    jobContainer.appendChild(startTrackCell);
 
-    const arrowCell = document.createElement('th');
+    const arrowCell = document.createElement('div');
     arrowCell.textContent = "\u279C";
-    arrowCell.classList.add('jobList-trackSeparator');
-    row.appendChild(arrowCell);
+    arrowCell.classList.add('jobList-trackSeparator', 'jobList-grid-metadata');
+    jobContainer.appendChild(arrowCell);
 
-    const destinationTrackCell = document.createElement('th');
-    destinationTrackCell.classList.add('interactive');
+    const destinationTrackCell = document.createElement('div');
+    destinationTrackCell.classList.add('interactive', 'jobList-grid-metadata');
     destinationTrackCell.textContent = replaceHyphens(task.destinationTrack);
     destinationTrackCell.style.background = colorForYardId(yardIdForTrack(task.destinationTrack));
     destinationTrackCell.addEventListener('click', () => scrollToTrack(task.destinationTrack));
-    row.appendChild(destinationTrackCell);
+    jobContainer.appendChild(destinationTrackCell);
 
-    for (let carIndex = 0; carIndex < task.cars.length; carIndex++) {
-      if (carIndex % CarsPerRow == 0) {
-        tbody.appendChild(row);
-        row = document.createElement('tr');
-      }
-      const carId = task.cars[carIndex];
-      const carCell = document.createElement('td');
-      carCell.classList.add(`jobList-carCell-${carId}`);
-      carCell.classList.add('interactive');
+    task.cars.forEach(carId => {
+      const carCell = document.createElement('div');
+      carCell.classList.add(`jobList-carCell-${carId}`, 'interactive');
       carCell.textContent = carId;
       carCell.addEventListener('click', () => followCar(carId, false));
-      row.appendChild(carCell);
-    }
-    if (row.children.length < CarsPerRow)
-      // add filler cells
-      for (let i = 0; i < CarsPerRow - (task.cars.length % CarsPerRow); i++)
-        row.appendChild(document.createElement('td'));
-    tbody.appendChild(row);
+      jobContainer.appendChild(carCell);
+    });
   });
 
-  return tbody;
+  return jobContainer;
 }
 
 function updateCarJobs() {
@@ -502,7 +487,7 @@ function followCar(carId, shouldScroll) {
   const jobListElems = jobListBody.querySelectorAll(`.jobList-carCell-${carId}`);
   for (const elem of jobListElems) {
     elem.classList.add('following');
-    elem.closest('tbody').classList.add('following');
+    elem.parentElement.classList.add('following');
   }
   if (shouldScroll && jobListElems.length > 0)
     jobListElems[0].scrollIntoView({ block: 'center' });

--- a/style.css
+++ b/style.css
@@ -46,7 +46,8 @@ table td {
   text-align:left;
   border-top:2px solid #ddd;
 }
-table th {
+table th,
+.jobList-grid-metadata {
   background:#eee;
   background:-webkit-gradient(linear, left top, left bottom, from(#f6f6f6), to(#eee));
   background:-moz-linear-gradient(top, #f6f6f6, #eee);
@@ -57,8 +58,9 @@ table td {
   vertical-align:top;
 }
 table thead:first-child tr th,
-table thead:first-child tr td {
-  border-top:0;
+table thead:first-child tr td,
+.jobList-grid:first-child div.jobList-jobHeader {
+  border-top: 0;
 }
 table tbody + tbody {
   border-top:2px solid #ddd;
@@ -118,10 +120,12 @@ table tbody:first-child > tr:first-child td {
 .interactive {
   cursor: pointer;
 }
-tbody.following {
+tbody.following,
+.jobList-grid.following {
   box-shadow: -4px 0px steelblue;
 }
-td.following {
+td.following,
+.jobList-grid > div.following {
   background: lightsteelblue;
 }
 img.leaflet-sidebar-tab-icon32 {
@@ -134,14 +138,30 @@ body {
   margin: 0px;
 }
 
+.jobList-grid > * {
+  padding: 3px;
+}
+.jobList-metadata-start {
+  grid-column-start: 1;
+}
+.jobList-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  width: 100%;
+  gap: 1px;
+}
 .jobList-trackSeparator {
   text-align: center;
 }
 .jobList-jobHeader {
+  grid-column: 1 / -1;
+  font-weight: bold;
   position: relative;
   border-top: black solid 4px;
-  padding-top: 5px;
-  padding-bottom: 5px;
+  padding: 5px 3px;
+}
+.jobList-grid > *:not(:first-child) {
+  outline: 1px solid #ddd;
 }
 .jobList-licenses {
   position: absolute;

--- a/style.css
+++ b/style.css
@@ -154,6 +154,7 @@ body {
   position: relative;
   display: inline flow-root;
   margin-right: 4px;
+  height: 100%;
 }
 .jobList-licenseBackground {
   position: absolute;


### PR DESCRIPTION
Nested tbodys aren't allowed in HTML and because of that not the complete width was used. I also fixed the "offset" background in the licenses (which is independent of the switch to grid, so could be separated into another pull request if necessary).

![grid](https://github.com/user-attachments/assets/fb5a38f5-d589-40dc-b0f0-bfcb3e39dfe6) ![tbody-license](https://github.com/user-attachments/assets/7367f9f6-d722-40b1-b5d0-a16a8813b7c5)

It also makes it easier to change the number of columns, as there is no need to "padding cells" and spans can be made "for the complete row". Although to be fair, the two "metadata"-rows (with the weight, length, profit, start and destination) would need to be redesigned as they assume there are exactly three columns.