### PR TITLE
Make compatible with B99.4

### DIFF
--- a/CarData.cs
+++ b/CarData.cs
@@ -1,7 +1,5 @@
 using DV.LocoRestoration;
-using DV.Logic.Job;
 using DV.ThingTypes;
-using DV.Utils;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
@@ -65,7 +63,7 @@ namespace DvMod.RemoteDispatch
         {
             var (carId, carData) = Updater.RunOnMainThread(() =>
             {
-                var car = SingletonBehaviour<IdGenerator>.Instance.GetTrainCarByCarGuid(guid);
+                var car = TrainCarRegistry.Instance.GetTrainCarByCarGuid(guid);
                 if (car == null || !ShouldReturnTrainCar(car))
                     return default;
                 return (car.ID, From(car));
@@ -81,7 +79,7 @@ namespace DvMod.RemoteDispatch
         {
             return Updater.RunOnMainThread(() =>
             {
-                return SingletonBehaviour<IdGenerator>.Instance
+                return TrainCarRegistry.Instance
                     .logicCarToTrainCar
                     .Values
                     .Where(ShouldReturnTrainCar)

--- a/CarUpdater.cs
+++ b/CarUpdater.cs
@@ -1,11 +1,11 @@
 using DV.LocoRestoration;
 using DV.RemoteControls;
+using DV.Simulation.Cars;
 using DV.Simulation.Controllers;
 using DV.ThingTypes;
 using DV.Utils;
 using HarmonyLib;
 using System.Linq;
-using UnityEngine;
 
 namespace DvMod.RemoteDispatch
 {
@@ -49,14 +49,14 @@ namespace DvMod.RemoteDispatch
                 Sessions.AddTag($"trainset-{trainset.id}");
         }
 
-        [HarmonyPatch(typeof(TrainCar), nameof(TrainCar.Update))]
+        [HarmonyPatch(typeof(SimController), nameof(SimController.Update))]
         public static class UpdatePatch
         {
-            public static void Postfix(TrainCar __instance)
+            public static void Postfix(SimController __instance)
             {
-                if (__instance.logicCar == null || __instance.isStationary)
+                if (__instance.train == null || __instance.train.logicCar == null || __instance.train.isStationary)
                     return;
-                MarkTrainsetAsDirty(__instance.trainset);
+                MarkTrainsetAsDirty(__instance.train.trainset);
             }
         }
 

--- a/HttpServer.cs
+++ b/HttpServer.cs
@@ -1,5 +1,3 @@
-using DV.Utils;
-using DV;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.IO.Compression;
@@ -184,7 +182,7 @@ namespace DvMod.RemoteDispatch
 
         private static bool IsValidJunctionId(int junctionId)
         {
-            return junctionId >= 0 && junctionId < SingletonBehaviour<WorldData>.Instance.OrderedJunctions.Length;
+            return junctionId >= 0 && junctionId < RailTrackRegistry.Instance.OrderedJunctions.Length;
         }
 
         private static async void HandleJunctionRequest(HttpListenerContext context)
@@ -207,7 +205,7 @@ namespace DvMod.RemoteDispatch
                     var newSelectedBranch = await Updater.RunOnMainThread(() =>
                     {
                         Main.DebugLog(() => $"Toggling J-{junctionId}.");
-                        var junction = SingletonBehaviour<WorldData>.Instance.OrderedJunctions[junctionId];
+                        var junction = RailTrackRegistry.Instance.OrderedJunctions[junctionId];
                         junction.Switch(Junction.SwitchMode.REGULAR);
                         return junction.selectedBranch;
                     }).ConfigureAwait(false);

--- a/JobData.cs
+++ b/JobData.cs
@@ -38,8 +38,8 @@ namespace DvMod.RemoteDispatch
         private static Dictionary<TrainCar, string> InitializeJobIdForCar()
         {
             return SingletonBehaviour<JobsManager>.Instance.jobToJobCars
-                .SelectMany(kvp => kvp.Value.Select(car => (car, job: kvp.Key)))
-                .ToDictionary(p => p.car, p => p.job.ID);
+                .SelectMany(kvp => kvp.Value.Select(car => (trainCar: car.TrainCar(), job: kvp.Key)))
+                .ToDictionary(p => p.trainCar, p => p.job.ID);
         }
 
         public static Job? JobForId(string jobId)
@@ -176,12 +176,14 @@ namespace DvMod.RemoteDispatch
             {
                 public static void Postfix(JobChainController __instance, string jobId)
                 {
-                    foreach (TrainCar car in __instance.trainCarsForJobChain)
+                    foreach (Car car in __instance.carsForJobChain)
                     {
+                        var trainCar = car.TrainCar();
+
                         if (jobId.Length == 0)
-                            jobIdForCar.Remove(car);
+                            jobIdForCar.Remove(trainCar);
                         else
-                            jobIdForCar[car] = jobId;
+                            jobIdForCar[trainCar] = jobId;
                         Sessions.AddTag("jobs");
                     }
                 }

--- a/LocoControl.cs
+++ b/LocoControl.cs
@@ -1,8 +1,5 @@
-using DV.Logic.Job;
 using DV.RemoteControls;
-using DV.Utils;
 using System.Collections.Specialized;
-using System.Linq;
 using UnityEngine;
 
 namespace DvMod.RemoteDispatch
@@ -16,7 +13,7 @@ namespace DvMod.RemoteDispatch
         
         public static RemoteControllerModule? GetLocoController(string guid)
         {
-            return SingletonBehaviour<IdGenerator>.Instance
+            return TrainCarRegistry.Instance
                 .GetTrainCarByCarGuid(guid)
                 ?.GetComponent<RemoteControllerModule>();
         }

--- a/RemoteDispatch.csproj
+++ b/RemoteDispatch.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
@@ -19,11 +19,13 @@
     <Reference Include="DV.Common"/>
     <Reference Include="DV.Interaction"/>
     <Reference Include="DV.PointSet"/>
+    <Reference Include="DV.RailTrack" />
     <Reference Include="DV.ThingTypes"/>
     <Reference Include="DV.Utils"/>
     <Reference Include="Microsoft.CSharp"/>
     <Reference Include="Newtonsoft.Json"/>
     <Reference Include="net.smkd.vector3d"/>
+    <Reference Include="WorldStreamer" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RemoteDispatch.csproj
+++ b/RemoteDispatch.csproj
@@ -4,7 +4,7 @@
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>DvMod.RemoteDispatch</RootNamespace>
-    <InformationalVersion>1.1.0</InformationalVersion>
+    <InformationalVersion>1.2.0</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/info.json
+++ b/info.json
@@ -2,7 +2,7 @@
   "Id": "RemoteDispatch",
   "DisplayName": "Remote Dispatch",
   "Author": "Zeibach",
-  "Version": "1.1.0",
+  "Version": "1.2.0",
   "AssemblyName": "RemoteDispatch.dll",
   "EntryMethod": "DvMod.RemoteDispatch.Main.Load",
   "LoadAfter": [ "PersistentJobsMod" ],

--- a/resources/repository.json
+++ b/resources/repository.json
@@ -1,7 +1,8 @@
 {
   "Releases":
   [
-      {"Id": "RemoteDispatch", "Version": "1.1.0", "DownloadUrl": "https://github.com/mspielberg/dv-remote-dispatch/releases/download/v1.1.0/RemoteDispatch_1.1.0.zip"},
+      {"Id": "RemoteDispatch", "Version": "1.2.0", "DownloadUrl": "https://github.com/mspielberg/dv-remote-dispatch/releases/download/v1.2.0/RemoteDispatch_1.2.0.zip"},
+	  {"Id": "RemoteDispatch", "Version": "1.1.0", "DownloadUrl": "https://github.com/mspielberg/dv-remote-dispatch/releases/download/v1.1.0/RemoteDispatch_1.1.0.zip"},
       {"Id": "RemoteDispatch", "Version": "1.0.4", "DownloadUrl": "https://github.com/mspielberg/dv-remote-dispatch/releases/download/v1.0.4/RemoteDispatch_1.0.4.zip"},
       {"Id": "RemoteDispatch", "Version": "1.0.3", "DownloadUrl": "https://github.com/mspielberg/dv-remote-dispatch/releases/download/v1.0.3/RemoteDispatch_1.0.3.zip"},
       {"Id": "RemoteDispatch", "Version": "1.0.2", "DownloadUrl": "https://github.com/mspielberg/dv-remote-dispatch/releases/download/v1.0.2/RemoteDispatch_1.0.2.zip"},


### PR DESCRIPTION
Updated references to match B99.4's structure.


TrainCar no longer has an `Update()` method, so I've used the `SimController.Update` and taken the `train` reference from there.

Fixes #30 

[RemoteDispatch B99.4 Unofficial.zip](https://github.com/user-attachments/files/19876423/RemoteDispatch.B99.4.Unofficial.zip)